### PR TITLE
Add Flake8 and Black checks to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,6 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.8
-    - name: Install
-      run: |
-        
     - name: Lint with Flake8
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install flake8
-        flake8 .
+        flake8 --count --statistics --show-source --jobs=$(nproc) .
 
   black-code-style:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+- push
+- pull_request
+
+jobs:
+
+  linting-flake8:
+
+    runs-on: ubuntu-18.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+    - name: Install
+      run: |
+        
+    - name: Lint with Flake8
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8
+        flake8 .
+
+  black-code-style:
+
+    runs-on: ubuntu-18.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+    - name: Check style with Black
+      run: |
+        python -m pip install --upgrade pip
+        pip install black
+        black --check --diff .


### PR DESCRIPTION
This is adding [Flake8](https://flake8.pycqa.org) code quality checks and [Black](https://github.com/psf/black) code style checks as jobs running in GitHub Actions. See *Checks* or *Actions* for results (you can dig all the way to the particular error messages).

Some of the errors overlap and after applying Black, the Flake8 errors will be greatly reduced as all the whitespace issues will be resolved. The tests now fail because the code does not conform to Flake8 and Black. I can fix the current issues in the code in the PR or later whatever makes more sense to you.

There is not much code yet in this project, but beginning is the best time to introduce good code guidelines and with Flake8 and Black these can be easily checked.

Let me know what you think.